### PR TITLE
zadig winusb not libusb

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -155,7 +155,7 @@ var app = new Vue({
                             <li><p>Now, if the program does not start immediatley, pressing RESET on the Daisy will cause the program to start running.</p></li>
                         </ol>
                         <p>
-                            On windows, you may have to update the driver to libusb.
+                            On windows, you may have to update the driver to WinUSB.
 
                             To do this, you can download the free software, Zadig. Instructions for this can be found on the DaisyWiki in the Windows toolchain instructions page.
                         </p>


### PR DESCRIPTION
This was the only place I could find the outdated libusb instruction. Everything else points to the wiki which is correct. 