### PR TITLE
Redirect to new tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- Programmer
+# Programmer
 
 **This tool is no longer used, and has been replaced by a [new version of the tool](https://flash.daisy.audio). The project sources have been left in place as a demonstration, or starting point for rolling custom DFU programming sites.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# Programmer
+ Programmer
+
+**This tool is no longer used, and has been replaced by a [new version of the tool](https://flash.daisy.audio). The project sources have been left in place as a demonstration, or starting point for rolling custom DFU programming sites.**
+
+**There will be no further development in this repo**.
+
+**The previous index.html has been renamed, and replaced with a simple redirect to the new tool.**
+
+---
+
 
 WebUSB programmer for Daisy (and other DFU-compatible chips/boards).
 

--- a/index.html
+++ b/index.html
@@ -1,53 +1,13 @@
 <!DOCTYPE html>
-<link rel="icon" href="./img/ES_Circle_Orange.PNG"></link>
-<html>
-    <head>
-        <!-- Required meta tags for BootstrapVue-->
-        <meta charset="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
-
-        <title>Daisy Web Programmer</title>
-        <!-- Required Stylesheets for BootstrapVue -->
-        <link
-            type="text/css"
-            rel="stylesheet"
-            href="https://unpkg.com/bootstrap/dist/css/bootstrap.min.css"
-        />
-        <link
-            type="text/css"
-            rel="stylesheet"
-            href="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.css"
-        />
-        <link type="text/css" rel="stylesheet" href="app/style.css"/>
-
-        <!-- Scripts for DFU -->
-	    <script src="dfu/dfu.js"></script>
-	    <script src="dfu/dfuse.js"></script>
-	    <script src="dfu/FileSaver.js"></script>
-        <script src="app/dfu-util.js"></script>
-
-        <!-- Load polyfills to support older browsers (for BootstrapVue? -- it was in the example) -->
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es2015%2CIntersectionObserver"></script>
-
-        <!-- Required scripts for BootstrapVue -->
-        <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
-        <script src="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.js"></script>
-
-    </head>
-    <body>
-        <div id="app">
-        </div>
-        <script src="./app/app.js"></script>
-
-	<!--markedjs -->
-	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
-
-
-	<!-- highlightjs -->
-	<link rel="stylesheet"
-        href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/arduino-light.min.css">
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
-
-    </body>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=https://flash.daisy.audio/">
+    <link rel="canonical" href="https://flash.daisy.audio/">
+</head>
+<body>
+  <h1>Redirecting to new tool..."</h1>
+  <p>If your browser does not automatically redirect, <a href="https://flash.daisy.audio/">click here</a>.</p>
+</body>
 </html>

--- a/old-index.html
+++ b/old-index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="icon" href="./img/ES_Circle_Orange.PNG"></link>
+<html>
+    <head>
+        <!-- Required meta tags for BootstrapVue-->
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+        <title>Daisy Web Programmer</title>
+        <!-- Required Stylesheets for BootstrapVue -->
+        <link
+            type="text/css"
+            rel="stylesheet"
+            href="https://unpkg.com/bootstrap/dist/css/bootstrap.min.css"
+        />
+        <link
+            type="text/css"
+            rel="stylesheet"
+            href="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.css"
+        />
+        <link type="text/css" rel="stylesheet" href="app/style.css"/>
+
+        <!-- Scripts for DFU -->
+	    <script src="dfu/dfu.js"></script>
+	    <script src="dfu/dfuse.js"></script>
+	    <script src="dfu/FileSaver.js"></script>
+        <script src="app/dfu-util.js"></script>
+
+        <!-- Load polyfills to support older browsers (for BootstrapVue? -- it was in the example) -->
+        <script src="https://polyfill.io/v3/polyfill.min.js?features=es2015%2CIntersectionObserver"></script>
+
+        <!-- Required scripts for BootstrapVue -->
+        <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14"></script>
+        <script src="https://unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.js"></script>
+
+    </head>
+    <body>
+        <div id="app">
+        </div>
+        <script src="./app/app.js"></script>
+
+	<!--markedjs -->
+	<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+
+
+	<!-- highlightjs -->
+	<link rel="stylesheet"
+        href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/arduino-light.min.css">
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
+
+    </body>
+</html>


### PR DESCRIPTION
This PR updates the README with information about no further development in this repo, and replaces the index of the github page with a basic redirect to the [new version of the tool](https://flash.daisy.audio).